### PR TITLE
Fix Cypress with Auth0

### DIFF
--- a/src/code/ng-demo-auth0/cypress/support/commands.ts
+++ b/src/code/ng-demo-auth0/cypress/support/commands.ts
@@ -7,8 +7,7 @@ Cypress.Commands.add('signIn', (username, password) => {
   cy.origin(Cypress.env('E2E_DOMAIN'), {args: {username, password}},
     ({username, password}) => {
       cy.get('input[name=username]').type(username);
-      cy.get('input[name=password]').type(password, {log: false});
-      cy.get('button[type=submit]').first().click();
+      cy.get('input[name=password]').type(`${password}{enter}`, {log: false});
     }
   )
 

--- a/src/docs/asciidoc/modules/ROOT/pages/chapter1.adoc
+++ b/src/docs/asciidoc/modules/ROOT/pages/chapter1.adoc
@@ -1941,8 +1941,7 @@ endif::[]
   cy.origin(Cypress.env('E2E_DOMAIN'), {args: {username, password}},
     ({username, password}) => {
       cy.get('input[name=username]').type(username);
-      cy.get('input[name=password]').type(password, {log: false});
-      cy.get('button[type=submit]').first().click();
+      cy.get('input[name=password]').type(`${password}{enter}`, {log: false});
     }
   )
 


### PR DESCRIPTION
More info on why this change is necessary is available in [this forum post](https://community.auth0.com/t/hidden-submit-button-breaking-cypress-tests/107782).